### PR TITLE
use local three.js modules via npm

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
-import * as THREE from 'https://unpkg.com/three@0.179.1/build/three.module.js';
-import { OrbitControls } from 'https://unpkg.com/three@0.179.1/examples/jsm/controls/OrbitControls.js';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 // ========================
 // Configuración y constantes


### PR DESCRIPTION
## Summary
- replace CDN imports with local `three` and `OrbitControls` modules

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689680d8a9188331a6c1484ffbc1d040